### PR TITLE
Adaption to Deviceinfo 0.1.0 with yaml config

### DIFF
--- a/sensord/main.cpp
+++ b/sensord/main.cpp
@@ -231,8 +231,8 @@ int main(int argc, char *argv[])
     if (parser.deviceInfo())
     {
         DeviceInfo *deviceInfo = new DeviceInfo();
-        if (deviceInfo->contains("sensorfwConfig")) {
-            defConfigFile = QString::fromStdString(deviceInfo->get("sensorfwConfig",
+        if (deviceInfo->contains("SensorfwConfig")) {
+            defConfigFile = QString::fromStdString(deviceInfo->get("SensorfwConfig",
                                                    defConfigFile.toStdString()));
         }
     }


### PR DESCRIPTION
Adjust sensorfw to work with Deviceinfo 0.1.0.
Which has a different syntax due to the change to the yaml config structure.
Thereby "sensorfwConfig" is renamed to "SensorfwConfig".
See bug report https://github.com/ubports/sensorfw/issues/1