### PR TITLE
add missing plugins

### DIFF
--- a/debian/libsensorfw-qt5-plugins.install
+++ b/debian/libsensorfw-qt5-plugins.install
@@ -39,3 +39,4 @@
 /usr/lib/sensord-qt5/libpegatronaccelerometeradaptor-qt5.so   
 /usr/lib/sensord-qt5/librotationsensor-qt5.so
 /usr/lib/sensord-qt5/libiiosensorsadaptor-qt5.so
+/usr/lib/sensord-qt5/libmagcoordinatealignfilter-qt5.so


### PR DESCRIPTION
this will fix magnet,and compass sensors
those 2 sensors usable too on waydroid, special in google maps
i dont know why maps app in open store cannot use the sensors,
but sensorsstatus app in openstore show those 2 sensors
tested on generic(gsi) arm64 halium 9, halium 10